### PR TITLE
Add EnvObserver and WritableFileObserver

### DIFF
--- a/dynflag.go
+++ b/dynflag.go
@@ -2,5 +2,6 @@
 
 package gorocksdb
 
+// #cgo CXXFLAGS: -std=c++11
 // #cgo LDFLAGS: -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy
 import "C"

--- a/env.go
+++ b/env.go
@@ -1,11 +1,55 @@
 package gorocksdb
 
-// #include "rocksdb/c.h"
+/*
+#include "rocksdb/c.h"
+#include "gorocksdb.h"
+*/
 import "C"
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+// EnvObserver allows for observation of mutating Env operations.
+// Consult |Env| in rocksdb/env.h for further details.
+type EnvObserver interface {
+	// Invoked just before a new WritableFile is created. Returns a
+	// WritableFileObserver which is associated with the result file.
+	NewWritableFile(fname string) WritableFileObserver
+	// Invoked just before |fname| is deleted.
+	DeleteFile(fname string)
+	// Invoked just before |dirname| is deleted.
+	DeleteDir(dirname string)
+	// Invoked just before |src| is renamed to |target|.
+	RenameFile(src, target string)
+	// Invoked just before |src| is linked to |target|.
+	LinkFile(src, target string)
+}
+
+// WritableFileObserver allows for observation of mutating WritableFile
+// operations. Consult |WritableFile| in rocksdb/env.h for further details.
+type WritableFileObserver interface {
+	// Inoked when |data| is appended to the file. Note that |data| is owned by
+	// RocksDB and must not be referenced after this call.
+	Append(data []byte)
+	// Invoked just before the file is closed.
+	Close()
+	// Invoked just before the file is Synced.
+	Sync()
+	// Invoked just before the file is Fsync'd. Note that this may in turn
+	// delegate to sync, and result in a call to the Sync() observer.
+	Fsync()
+	// Invoked just before a range of the file is synced.
+	RangeSync(offset, nbytes int64)
+}
 
 // Env is a system call environment used by a database.
 type Env struct {
 	c *C.rocksdb_env_t
+
+	// |handle| is held by C++ classes. Reference here to avoid GC.
+	handle *envObserverHandle
 }
 
 // NewDefaultEnv creates a default environment.
@@ -15,7 +59,18 @@ func NewDefaultEnv() *Env {
 
 // NewNativeEnv creates a Environment object.
 func NewNativeEnv(c *C.rocksdb_env_t) *Env {
-	return &Env{c}
+	return &Env{c: c}
+}
+
+func NewObservedEnv(obv EnvObserver) *Env {
+	handle := &envObserverHandle{
+		EnvObserver: obv,
+		fileHandles: make(map[*wfObserverHandle]struct{}),
+	}
+	return &Env{
+		c:      C.gorocksdb_create_hooked_env(unsafe.Pointer(handle)),
+		handle: handle,
+	}
 }
 
 // The number of background worker threads of a specific thread pool
@@ -36,4 +91,102 @@ func (self *Env) SetHighPriorityBackgroundThreads(n int) {
 func (self *Env) Destroy() {
 	C.rocksdb_env_destroy(self.c)
 	self.c = nil
+}
+
+// Concrete type wrapping |EnvObserver|, for passing through C++.
+type envObserverHandle struct {
+	EnvObserver
+
+	// References to created |WritableFileObserver|'s which must be held for GC.
+	fileHandles map[*wfObserverHandle]struct{}
+}
+
+// Concrete type wrapping |WritableFileObserver|, for passing through C++.
+type wfObserverHandle struct {
+	WritableFileObserver
+
+	env *envObserverHandle
+}
+
+//export gorocksdb_env_new_writable_file
+func gorocksdb_env_new_writable_file(state unsafe.Pointer, fnameRaw *C.char,
+	fnameLen C.int) unsafe.Pointer {
+
+	env := (*envObserverHandle)(state)
+	wf := &wfObserverHandle{env.NewWritableFile(C.GoStringN(fnameRaw, fnameLen)), env}
+
+	// Reference |wf| until it's deleted from the C++ side.
+	env.fileHandles[wf] = struct{}{}
+
+	return unsafe.Pointer(wf)
+}
+
+//export gorocksdb_env_delete_file
+func gorocksdb_env_delete_file(state unsafe.Pointer, fnameRaw *C.char, fnameLen C.int) {
+	env := (*envObserverHandle)(state)
+	env.DeleteFile(C.GoStringN(fnameRaw, fnameLen))
+}
+
+//export gorocksdb_env_delete_dir
+func gorocksdb_env_delete_dir(state unsafe.Pointer, fnameRaw *C.char, fnameLen C.int) {
+	env := (*envObserverHandle)(state)
+	env.DeleteDir(C.GoStringN(fnameRaw, fnameLen))
+}
+
+//export gorocksdb_env_rename_file
+func gorocksdb_env_rename_file(state unsafe.Pointer, srcRaw *C.char, srcLen C.int,
+	targetRaw *C.char, targetLen C.int) {
+
+	env := (*envObserverHandle)(state)
+	env.RenameFile(C.GoStringN(srcRaw, srcLen), C.GoStringN(targetRaw, targetLen))
+}
+
+//export gorocksdb_env_link_file
+func gorocksdb_env_link_file(state unsafe.Pointer, srcRaw *C.char, srcLen C.int,
+	targetRaw *C.char, targetLen C.int) {
+
+	env := (*envObserverHandle)(state)
+	env.LinkFile(C.GoStringN(srcRaw, srcLen), C.GoStringN(targetRaw, targetLen))
+}
+
+//export gorocksdb_wf_dtor
+func gorocksdb_wf_dtor(state unsafe.Pointer) {
+	wf := (*wfObserverHandle)(state)
+	// Free from |env.fileHandles| so that GC can reclaim the handle & observer.
+	delete(wf.env.fileHandles, wf)
+}
+
+//export gorocksdb_wf_append
+func gorocksdb_wf_append(state unsafe.Pointer, raw *C.char, rawLen C.size_t) {
+	wf := (*wfObserverHandle)(state)
+
+	var data []byte
+
+	// Initialize |data| to the underlying |raw| array, without a copy.
+	header := (*reflect.SliceHeader)(unsafe.Pointer(&data))
+	header.Data = uintptr(unsafe.Pointer(raw))
+	header.Len = int(rawLen)
+	header.Cap = int(rawLen)
+
+	wf.Append(data)
+}
+
+//export gorocksdb_wf_close
+func gorocksdb_wf_close(state unsafe.Pointer) {
+	(*wfObserverHandle)(state).Close()
+}
+
+//export gorocksdb_wf_sync
+func gorocksdb_wf_sync(state unsafe.Pointer) {
+	(*wfObserverHandle)(state).Sync()
+}
+
+//export gorocksdb_wf_fsync
+func gorocksdb_wf_fsync(state unsafe.Pointer) {
+	(*wfObserverHandle)(state).Fsync()
+}
+
+//export gorocksdb_wf_range_sync
+func gorocksdb_wf_range_sync(state unsafe.Pointer, offset, nbytes C.size_t) {
+	(*wfObserverHandle)(state).RangeSync(int64(offset), int64(nbytes))
 }

--- a/gorocksdb.h
+++ b/gorocksdb.h
@@ -28,3 +28,7 @@ extern void gorocksdb_mergeoperator_delete_value(void* state, const char* v, siz
 /* Slice Transform */
 
 extern rocksdb_slicetransform_t* gorocksdb_slicetransform_create(void* state);
+
+/* Hooked Env */
+
+extern rocksdb_env_t* gorocksdb_create_hooked_env(void* state);

--- a/hooked_env.cpp
+++ b/hooked_env.cpp
@@ -1,0 +1,86 @@
+#include "hooked_env.hpp"
+#include "hooked_writable_file.hpp"
+
+#include <iostream>
+
+extern "C" {
+#include "gorocksdb.h"
+#include "_cgo_export.h"
+}
+
+using rocksdb::EnvOptions;
+using rocksdb::EnvWrapper;
+using rocksdb::Status;
+using rocksdb::WritableFile;
+using std::unique_ptr;
+
+HookedEnv::HookedEnv(void* state)
+  : rocksdb::EnvWrapper(rocksdb::Env::Default()),
+    state_(state) { }
+
+HookedEnv::~HookedEnv() { }
+
+Status HookedEnv::NewWritableFile(const std::string& fname,
+                                  unique_ptr<WritableFile>* result,
+                                  const EnvOptions& options) {
+
+  void* file_state = gorocksdb_env_new_writable_file(state_,
+      (char*)(fname.c_str()), fname.length());
+
+  // Call down into wrapper subclass to get an actual delegate.
+  unique_ptr<WritableFile> delegate;
+  Status status = EnvWrapper::NewWritableFile(fname, &delegate, options);
+
+  // Return a hooked implementation of the |delegate|.
+  result->reset(new HookedWritableFile(file_state, std::move(delegate)));
+  return status;
+}
+
+Status HookedEnv::DeleteFile(const std::string& fname) {
+  gorocksdb_env_delete_file(state_, (char*)(fname.c_str()), fname.length());
+  return EnvWrapper::DeleteFile(fname);
+}
+
+Status HookedEnv::DeleteDir(const std::string& dirname) {
+  gorocksdb_env_delete_dir(state_, (char*)(dirname.c_str()), dirname.length());
+  return EnvWrapper::DeleteDir(dirname);
+}
+
+Status HookedEnv::RenameFile(const std::string& src,
+                             const std::string& target) {
+  gorocksdb_env_rename_file(state_,
+      (char*)(src.c_str()),
+      src.length(),
+      (char*)(target.c_str()),
+      target.length());
+  return EnvWrapper::RenameFile(src, target);
+}
+
+Status HookedEnv::LinkFile(const std::string& src,
+                           const std::string& target) {
+  gorocksdb_env_link_file(state_,
+      (char*)(src.c_str()),
+      src.length(),
+      (char*)(target.c_str()),
+      target.length());
+  return EnvWrapper::LinkFile(src, target);
+}
+
+
+extern "C" {
+
+// Note: this definition is copied from github.com/facebook/rocksdb/db/c.cc:339
+// We must copy, as this struct is defined in a .cc we don't have access too.
+struct rocksdb_env_t {
+  rocksdb::Env* rep;
+  bool is_default;
+};
+
+rocksdb_env_t* gorocksdb_create_hooked_env(void* state) {
+  rocksdb_env_t* result = new rocksdb_env_t;
+  result->rep = new HookedEnv(state);
+  result->is_default = false;
+  return result;
+}
+
+} // extern "C"

--- a/hooked_env.hpp
+++ b/hooked_env.hpp
@@ -1,0 +1,37 @@
+#ifndef HOOKED_ENV_HPP
+#define HOOKED_ENV_HPP
+
+#include <rocksdb/env.h>
+#include <memory>
+
+// Implementation of rocksdb::Env which notifies cgo hooks of calls to
+// designated methods. Actual handling of calls is delegated to EnvWrapper
+// subclass.
+class HookedEnv : public rocksdb::EnvWrapper {
+ public:
+
+  // |state| is an opaque pointer which is passed back into cgo hooks.
+  HookedEnv(void* state);
+
+  virtual ~HookedEnv() override;
+
+  virtual rocksdb::Status NewWritableFile(
+      const std::string& fname,
+      std::unique_ptr<rocksdb::WritableFile>* result,
+      const rocksdb::EnvOptions& options) override;
+
+  virtual rocksdb::Status DeleteFile(const std::string& fname) override;
+
+  virtual rocksdb::Status DeleteDir(const std::string& dirname) override;
+
+  virtual rocksdb::Status RenameFile(const std::string& src,
+                                     const std::string& target) override;
+
+  virtual rocksdb::Status LinkFile(const std::string& src,
+                                   const std::string& target) override;
+ private:
+
+  void* state_;
+};
+
+#endif // #ifndef HOOKED_ENV_HPP

--- a/hooked_writable_file.cpp
+++ b/hooked_writable_file.cpp
@@ -1,0 +1,48 @@
+#include "hooked_writable_file.hpp"
+
+#include <iostream>
+
+extern "C" {
+#include "_cgo_export.h"
+}
+
+using rocksdb::Slice;
+using rocksdb::Status;
+using rocksdb::WritableFileWrapper;
+using std::unique_ptr;
+
+HookedWritableFile::HookedWritableFile(void* state,
+      unique_ptr<WritableFile> delegate)
+  : WritableFileWrapper(delegate.get()),
+    state_(state),
+    delegate_(std::move(delegate)) {
+}
+
+HookedWritableFile::~HookedWritableFile() {
+  gorocksdb_wf_dtor(state_);
+}
+
+Status HookedWritableFile::Append(const Slice& data) {
+  gorocksdb_wf_append(state_, (char*)data.data(), data.size());
+  return WritableFileWrapper::Append(data);
+}
+
+Status HookedWritableFile::Close() {
+  gorocksdb_wf_close(state_);
+  return WritableFileWrapper::Close();
+}
+
+Status HookedWritableFile::Sync() {
+  gorocksdb_wf_sync(state_);
+  return WritableFileWrapper::Sync();
+}
+
+Status HookedWritableFile::Fsync() {
+  gorocksdb_wf_fsync(state_);
+  return WritableFileWrapper::Fsync();
+}
+
+Status HookedWritableFile::RangeSync(off_t offset, off_t nbytes) {
+  gorocksdb_wf_range_sync(state_, offset, nbytes);
+  return WritableFileWrapper::RangeSync(offset, nbytes);
+}

--- a/hooked_writable_file.hpp
+++ b/hooked_writable_file.hpp
@@ -1,0 +1,38 @@
+#ifndef HOOKED_WRITABLE_FILE_HPP
+#define HOOKED_WRITABLE_FILE_HPP
+
+#include <rocksdb/env.h>
+#include <memory>
+
+// Implementation of rocksdb::WritableFile which notifies cgo hooks of calls to
+// designated methods. Actual handling of calls is delegated to
+// WritableFileWrapper subclass.
+class HookedWritableFile : public rocksdb::WritableFileWrapper {
+ public:
+
+  // |state| is an opaque pointer which is passed back into cgo hooks.
+  HookedWritableFile(void* state, std::unique_ptr<WritableFile> delegate);
+
+  virtual ~HookedWritableFile() override;
+
+  virtual rocksdb::Status Append(const rocksdb::Slice& data) override;
+
+  virtual rocksdb::Status Close() override;
+
+  virtual rocksdb::Status Sync() override;
+
+  virtual rocksdb::Status Fsync() override;
+
+ protected:
+
+  virtual rocksdb::Status RangeSync(off_t offset, off_t nbytes) override;
+
+ private:
+
+  void* state_;
+
+  // Delegate is exclusively owned by HookedWritableFile.
+  std::unique_ptr<rocksdb::WritableFile> delegate_;
+};
+
+#endif


### PR DESCRIPTION
These interface types can be plugged into an Env via NewObservedEnv().
A number of hooks are added to facilitate Go-side callbacks from
C++ call contexts.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pippio/gorocksdb/1)

<!-- Reviewable:end -->
