### PR TITLE
Iterator amortizes CGO next / key / value calls

### DIFF
--- a/batched_iterator.cpp
+++ b/batched_iterator.cpp
@@ -1,0 +1,67 @@
+#include <rocksdb/iterator.h>
+#include <rocksdb/c.h>
+#include <memory>
+
+using rocksdb::Iterator;
+using rocksdb::Slice;
+
+extern "C" {
+
+// Note: this definition is copied from github.com/facebook/rocksdb/db/c.cc:89
+// We must copy, as this struct is defined in a .cc we don't have access too.
+struct rocksdb_iterator_t        { Iterator*         rep; };
+
+size_t batched_iter_next(rocksdb_iterator_t* cit, size_t arena_len,
+    char* arena_out);
+
+} // extern "C"
+
+// Macro which appends rocksdb::Slice |s| to |arena_out|, prefixed by size.
+#define APPEND_SLICE(s) (               \
+  {                                     \
+    size_t l = s.size();                \
+    arena_out[0] = char((l)>>24);       \
+    arena_out[1] = char((l)>>16);       \
+    arena_out[2] = char((l)>>8);        \
+    arena_out[3] = char((l)>>0);        \
+    memcpy(arena_out + 4, s.data(), l); \
+    arena_out = arena_out + 4 + l;      \
+    arena_off += 4 + l;                 \
+  }                                     \
+)
+
+// batched_iter_next fills up to |arena_len| bytes of |arena_out| with successive
+// length-prefixed keys and values of |cit|. The input |cit| must be Valid().
+// At return, the last key & value stored in |arena_out| is at the current
+// iterator offset. If |arena_len| is insufficient to store the next key,
+// then the iterator is still stepped but |arena_out| left empty.
+size_t batched_iter_next(rocksdb_iterator_t* cit, size_t arena_len,
+    char* arena_out) {
+
+  Iterator* it = cit->rep;
+  size_t arena_off = 0;
+
+  while(true){
+    it->Next();
+
+    if (!it->Valid()) {
+      break;
+    }
+
+    Slice key = it->key();
+    Slice val = it->value();
+
+    if ((arena_off + 8 + key.size() + val.size()) > arena_len) {
+      // Insufficient arena buffer remains for this key/value.
+      if (arena_off > 0) {
+        // At least one key/value is already being returned.
+        // Step backwards to save this iterator offset for later.
+        it->Prev();
+      }
+      break;
+    }
+    APPEND_SLICE(key);
+    APPEND_SLICE(val);
+  }
+  return arena_off;
+}

--- a/iterator.go
+++ b/iterator.go
@@ -1,12 +1,23 @@
 package gorocksdb
 
-// #include <stdlib.h>
-// #include "rocksdb/c.h"
+/*
+#include <stdlib.h>
+#include "rocksdb/c.h"
+
+size_t batched_iter_next(rocksdb_iterator_t* cit, size_t arena_len, char* arena);
+
+*/
 import "C"
 import (
 	"bytes"
 	"errors"
 	"unsafe"
+)
+
+const (
+	// Min and max arena sizes used for pre-fetching iterator keys & values.
+	minArenaSize = 4096
+	maxArenaSize = minArenaSize * 1024
 )
 
 // Iterator provides a way to seek to specific keys and iterate through
@@ -28,27 +39,47 @@ import (
 //
 type Iterator struct {
 	c *C.rocksdb_iterator_t
+
+	// CGO calls are expensive. We amortize this cost by batching iteration and
+	// key/value retrieval into a memory arena, populated from C++ and read from
+	// Go. For the common case, this greatly reduces the number of required CGO
+	// calls in exchange for an extra copy.
+	arena, remainder []byte
 }
 
 // NewNativeIterator creates a Iterator object.
 func NewNativeIterator(c unsafe.Pointer) *Iterator {
-	return &Iterator{(*C.rocksdb_iterator_t)(c)}
+	return &Iterator{
+		c:     (*C.rocksdb_iterator_t)(c),
+		arena: make([]byte, minArenaSize),
+	}
 }
 
 // Valid returns false only when an Iterator has iterated past either the
 // first or the last key in the database.
 func (iter *Iterator) Valid() bool {
+	if len(iter.remainder) != 0 {
+		return true
+	}
 	return C.rocksdb_iter_valid(iter.c) != 0
 }
 
 // ValidForPrefix returns false only when an Iterator has iterated past the
 // first or the last key in the database or the specified prefix.
 func (iter *Iterator) ValidForPrefix(prefix []byte) bool {
-	return C.rocksdb_iter_valid(iter.c) != 0 && bytes.HasPrefix(iter.Key().Data(), prefix)
+	return iter.Valid() && bytes.HasPrefix(iter.Key().Data(), prefix)
 }
 
 // Key returns the key the iterator currently holds.
 func (iter *Iterator) Key() *Slice {
+	if len(iter.remainder) != 0 {
+		return &Slice{
+			data:  byteToChar(iter.remainder[4:]),
+			size:  parseLenPrefix(iter.remainder),
+			freed: true,
+		}
+	}
+
 	var cLen C.size_t
 	cKey := C.rocksdb_iter_key(iter.c, &cLen)
 	if cKey == nil {
@@ -59,6 +90,16 @@ func (iter *Iterator) Key() *Slice {
 
 // Value returns the value in the database the iterator currently holds.
 func (iter *Iterator) Value() *Slice {
+	if len(iter.remainder) != 0 {
+		var keyLen = parseLenPrefix(iter.remainder)
+
+		return &Slice{
+			data:  byteToChar(iter.remainder[8+keyLen:]),
+			size:  parseLenPrefix(iter.remainder[4+keyLen:]),
+			freed: true,
+		}
+	}
+
 	var cLen C.size_t
 	cVal := C.rocksdb_iter_value(iter.c, &cLen)
 	if cVal == nil {
@@ -69,28 +110,51 @@ func (iter *Iterator) Value() *Slice {
 
 // Next moves the iterator to the next sequential key in the database.
 func (iter *Iterator) Next() {
-	C.rocksdb_iter_next(iter.c)
+	if len(iter.remainder) != 0 {
+		// Iterate over current key & value.
+		iter.remainder = iter.remainder[4+parseLenPrefix(iter.remainder):]
+		iter.remainder = iter.remainder[4+parseLenPrefix(iter.remainder):]
+	}
+
+	if len(iter.remainder) == 0 {
+		if iter.remainder != nil && len(iter.arena) < maxArenaSize {
+			// If we full consumed the previously read arena, then double its
+			// size up to a bound.
+			iter.arena = make([]byte, len(iter.arena)*2)
+		}
+
+		var offset = C.batched_iter_next(iter.c, C.size_t(len(iter.arena)),
+			byteToChar(iter.arena))
+		iter.remainder = iter.arena[:offset]
+	}
 }
 
 // Prev moves the iterator to the previous sequential key in the database.
 func (iter *Iterator) Prev() {
+	if len(iter.remainder) != 0 {
+		// Seek the underlying iterator to the current key before stepping to Prev.
+		iter.Seek(iter.Key().Data())
+	}
 	C.rocksdb_iter_prev(iter.c)
 }
 
 // SeekToFirst moves the iterator to the first key in the database.
 func (iter *Iterator) SeekToFirst() {
 	C.rocksdb_iter_seek_to_first(iter.c)
+	iter.remainder = nil
 }
 
 // SeekToLast moves the iterator to the last key in the database.
 func (iter *Iterator) SeekToLast() {
 	C.rocksdb_iter_seek_to_last(iter.c)
+	iter.remainder = nil
 }
 
 // Seek moves the iterator to the position greater than or equal to the key.
 func (iter *Iterator) Seek(key []byte) {
 	cKey := byteToChar(key)
 	C.rocksdb_iter_seek(iter.c, cKey, C.size_t(len(key)))
+	iter.remainder = nil
 }
 
 // Err returns nil if no errors happened during iteration, or the actual
@@ -109,4 +173,9 @@ func (iter *Iterator) Err() error {
 func (iter *Iterator) Close() {
 	C.rocksdb_iter_destroy(iter.c)
 	iter.c = nil
+	iter.remainder = nil
+}
+
+func parseLenPrefix(b []byte) C.size_t {
+	return C.size_t(b[0]<<24) | C.size_t(b[1]<<16) | C.size_t(b[2]<<8) | C.size_t(b[3]<<0)
 }

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -1,6 +1,7 @@
 package gorocksdb
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/facebookgo/ensure"
@@ -28,4 +29,107 @@ func TestIterator(t *testing.T) {
 	}
 	ensure.Nil(t, iter.Err())
 	ensure.DeepEqual(t, actualKeys, givenKeys)
+}
+
+func TestIteratorSeeking(t *testing.T) {
+	db := newTestDB(t, "TestIteratorSeeking", nil)
+	defer db.Close()
+
+	wo := NewDefaultWriteOptions()
+	for i := int64(100); i != 200; i++ {
+		var key, val = []byte(strconv.FormatInt(i, 10)), []byte(strconv.FormatInt(i, 16))
+		ensure.Nil(t, db.Put(wo, key, val))
+	}
+
+	ro := NewDefaultReadOptions()
+	iter := db.NewIterator(ro)
+	defer iter.Close()
+
+	expect := func(i int64) {
+		ensure.True(t, iter.Valid())
+		ensure.DeepEqual(t, string(iter.Key().Data()), strconv.FormatInt(i, 10))
+		ensure.DeepEqual(t, string(iter.Value().Data()), strconv.FormatInt(i, 16))
+	}
+
+	// Next followed by SeekToFirst works as expected.
+	for i := 0; i != 2; i++ {
+		iter.SeekToFirst()
+		expect(100)
+		iter.Next()
+		expect(101)
+		iter.Next()
+		expect(102)
+	}
+
+	// As does Prev.
+	iter.Prev()
+	expect(101)
+	iter.Next()
+	expect(102)
+
+	// Seek followed by Next.
+	iter.Seek([]byte("132"))
+	expect(132)
+	iter.Next()
+	expect(133)
+	iter.Seek([]byte("122"))
+	expect(122)
+	iter.Next()
+	expect(123)
+
+	// SeekToLast followed by Prev.
+	iter.SeekToLast()
+	expect(199)
+	iter.Prev()
+	expect(198)
+	iter.Next()
+	expect(199)
+
+	// Step beyond last item.
+	iter.Next()
+	ensure.False(t, iter.Valid())
+
+	iter.SeekToFirst()
+	expect(100)
+	iter.Next()
+	expect(101)
+	iter.Prev()
+	expect(100)
+
+	// Step before first element.
+	iter.Prev()
+	ensure.False(t, iter.Valid())
+
+	// Expect the arena grew once (at most two Nexts in a sequence).
+	ensure.DeepEqual(t, len(iter.arena), minArenaSize*2)
+
+	// Establish fixture where the arena is too small to hold a key/value
+	iter.SeekToFirst()
+	iter.arena = make([]byte, 8)
+	iter.remainder = nil
+
+	// Next & accessors still work as expected, though arena isn't used.
+	iter.Next()
+	ensure.DeepEqual(t, len(iter.remainder), 0)
+	expect(101)
+
+	// Subsequent iterations do grow the arena each time its drained.
+	iter.Next() // Drains.
+	ensure.DeepEqual(t, len(iter.arena), 16)
+	ensure.DeepEqual(t, len(iter.remainder), 13)
+	expect(102)
+
+	iter.Next() // Drains.
+	ensure.DeepEqual(t, len(iter.arena), 32)
+	ensure.DeepEqual(t, len(iter.remainder), 26)
+	expect(103)
+	iter.Next()
+	ensure.DeepEqual(t, len(iter.arena), 32)
+	ensure.DeepEqual(t, len(iter.remainder), 13)
+	expect(104)
+
+	iter.Next() // Drains.
+	ensure.DeepEqual(t, len(iter.arena), 64)
+	ensure.DeepEqual(t, len(iter.remainder), 52)
+	expect(105)
 }


### PR DESCRIPTION
Iterator.Next pre-fetches copied keys and values into a memory arena.
Further calls to Next, Key, and Value are satisfied directly from that
arena without a CGO call, at the expense of requiring an extra copy.

The arena starts at 4K and grows (exponentially) every time it is fully
drained, without an interleaving Seek. This is intended to dynamically
balance the cost of pre-fetches with the Iterator's access pattern.

In synthetic Arbor reporting benchmarks, this change is provides a
2.5-3x improvement in scan throughput.
 
Issue #3157

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/arbortech/gorocksdb/4)
<!-- Reviewable:end -->
